### PR TITLE
Added error checking for setting browsable attribute

### DIFF
--- a/LineGrinder - Source/ctlFileManagerDisplay.cs
+++ b/LineGrinder - Source/ctlFileManagerDisplay.cs
@@ -688,9 +688,15 @@ namespace LineGrinder
             else wantBrowsable = true;
 
             PropertyDescriptor descriptor = TypeDescriptor.GetProperties(fileManagersObj.GetType())[propertyName];
-            BrowsableAttribute attrib = (BrowsableAttribute)descriptor.Attributes[typeof(BrowsableAttribute)];
-            FieldInfo browsable = attrib.GetType().GetField("browsable", BindingFlags.NonPublic | BindingFlags.Instance);
-            browsable.SetValue(attrib, wantBrowsable);
+            if(descriptor != null) {
+	            BrowsableAttribute attrib = (BrowsableAttribute)descriptor.Attributes[typeof(BrowsableAttribute)];
+	            if(attrib != null) {
+    		        FieldInfo browsable = attrib.GetType().GetField("browsable", BindingFlags.NonPublic | BindingFlags.Instance);
+    		        if(browsable != null) {
+            			browsable.SetValue(attrib, wantBrowsable);
+            		}
+            	}
+            }
         }
 
     }


### PR DESCRIPTION
Adding error checking in this method allows LineGrinder (Release version) to run via mono on Linux. 

Tested loading gbr and drl, then exporting GCode on amd64 kernel 6.11.1-arch1-1 with mono version 6.12.0.